### PR TITLE
Fix typo in container repository domain

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,5 +1,5 @@
 # This is a test.
 
-registry = "ghrc.io"
+registry = "ghcr.io"
 
 # GH rocks


### PR DESCRIPTION
Hi `totallynotp/registry-test`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).
We noticed that you have mispelled the name of a container registry domain. A malicious actor in control of that misspelled domain could perform an attack on your software supply chain.
